### PR TITLE
Add support for the jed/xjed editor

### DIFF
--- a/src/menu.rs
+++ b/src/menu.rs
@@ -393,6 +393,13 @@ impl<'a, 'b> Menu<'a, 'b> {
                 } else {
                     command.arg(path);
                 }
+	    }
+            "jed" | "xjed" => {
+	        command.arg(path);
+		if let Some(l) = line_num {
+		    command.arg("-g");
+		    command.arg(format!("{l}"));
+		}
             }
             _ => {
                 command.arg(path);


### PR DESCRIPTION
The editor `jed` (and its graphical sibling `xjed`) uses the option `-g` to go to a given linenumber:

```sh
jed $FILE -g $LINENO
```

This pull-request adds support for `jed`/`xjed`.
