### PR TITLE
Point to dynamic link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cargo build --release
 ```
 
 ### Links
-[crates.io](https://crates.io/crates/treegrep) | [GitHub](https://github.com/4imothy/treegrep) | [AUR](https://aur.archlinux.org/packages/treegrep-bin) | [NetBSD](https://mail-index.netbsd.org/pkgsrc-changes/2024/01/11/msg290674.html)
+[crates.io](https://crates.io/crates/treegrep) | [GitHub](https://github.com/4imothy/treegrep) | [AUR](https://aur.archlinux.org/packages/treegrep-bin) | [NetBSD](https://pkgsrc.se/sysutils/treegrep)
 
 
 https://github.com/4imothy/treegrep/assets/40186632/9c85c309-df78-4996-8127-ee5ad9f91ec3


### PR DESCRIPTION
Probably better to point to our online package search page result rather than, to a static commit link for v0.1.2

Updating to 0.1.3 right now.